### PR TITLE
added stamp and frame_id to message

### DIFF
--- a/src/tracking.cpp
+++ b/src/tracking.cpp
@@ -337,6 +337,8 @@ void callback (const pointcloud_msgs::PointCloud2_Segments& msg ){
             c_.cluster_id.push_back(v_[i].cluster_id[k]);
         }
 
+        c_.header.stamp = ros::Time::now();
+        c_.header.frame_id = msg.header.frame_id;
         c_.factor = msg.factor ;
         c_.overlap = msg.overlap ;
         c_.num_scans = msg.num_scans ;


### PR DESCRIPTION
Added timestamp and passed frame_id from incoming message to publishing message, in PointCloud2_Segments callback.